### PR TITLE
make project compatible with Swift 1.2

### DIFF
--- a/TableViewCellWithAutoLayout/AppDelegate.swift
+++ b/TableViewCellWithAutoLayout/AppDelegate.swift
@@ -12,8 +12,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate
 {
     var window: UIWindow?
     
-    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: NSDictionary?) -> Bool
-    {
+    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject : AnyObject]?) -> Bool {
         // Override point for customization after application launch.
         window = UIWindow(frame: UIScreen.mainScreen().bounds)
         var viewController = TableViewController(style: .Plain)

--- a/TableViewCellWithAutoLayout/TableViewController/TableViewController.swift
+++ b/TableViewCellWithAutoLayout/TableViewController/TableViewController.swift
@@ -13,11 +13,6 @@ class TableViewController: UITableViewController
     
     var model = Model()
     
-    override init(nibName nibNameOrNil: String!, bundle nibBundleOrNil: NSBundle!)
-    {
-        super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
-    }
-    
     override init(style: UITableViewStyle)
     {
         super.init(style: style)
@@ -94,7 +89,7 @@ class TableViewController: UITableViewController
         
         model = Model()
         
-        tableView.deleteRowsAtIndexPaths(rowsToDelete, withRowAnimation: .Automatic)
+        tableView.deleteRowsAtIndexPaths(rowsToDelete as [AnyObject], withRowAnimation: .Automatic)
     }
     
     // Adds a single row to the table view


### PR DESCRIPTION
Xcode 6.3 breaks your demo project.

To fix it, I had to update a few calls and completely remove another one (I wonder if Apple doesn't want UIViewController subclasses to be able to directly call `init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: NSBundle?)` anymore?  Doesn't make much sense, since that's UIViewController's designated initializer.